### PR TITLE
macros

### DIFF
--- a/core/examples/family_tree.rs
+++ b/core/examples/family_tree.rs
@@ -1,0 +1,70 @@
+use anyhow::Result;
+use relalg::{relalg, Database, Expression};
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct Person {
+    id: u32,
+    father_id: Option<u32>,
+    mother_id: Option<u32>,
+    name: String,
+}
+
+fn main() -> Result<()> {
+    let mut got = Database::new();
+    let person = got.new_relation::<Person>("Person");
+    person.insert(
+        vec![
+            Person {
+                id: 1,
+                name: "Arya Stark".to_string(),
+                father_id: Some(2),
+                mother_id: Some(3),
+            },
+            Person {
+                id: 2,
+                name: "Eddard Stark".to_string(),
+                father_id: None,
+                mother_id: None,
+            },
+            Person {
+                id: 3,
+                name: "Catelyn Stark".to_string(),
+                father_id: None,
+                mother_id: None,
+            },
+            Person {
+                id: 4,
+                name: "John Snow".to_string(),
+                father_id: None,
+                mother_id: None,
+            },
+        ]
+        .into(),
+        &got,
+    )?;
+
+    let ariyas_father = relalg! {
+        select [|p| (p.father_id.unwrap(), ())] from (person)
+        where
+            [|p| p.father_id.is_some() && p.name == "Arya Stark"]
+
+    };
+
+    let persons_name = relalg! {
+        select [|p| (p.id, p.name.clone())] from (person)
+    };
+
+    let fathers_name = relalg! {
+        select * from (
+            (ariyas_father) join (persons_name) on [|_, _, name| name.clone()]
+        )
+    };
+
+    let names = fathers_name.evaluate(&got);
+
+    for name in names.iter() {
+        println!("{:?}", name);
+    }
+
+    Ok(())
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,11 +1,10 @@
-use std::fmt::Debug;
-
 mod database;
 mod expression;
+mod macros;
 mod tools;
 
-pub use database::Database;
-pub use expression::{Join, Project, Relation, Select, View};
+pub use database::{Database, Tuples};
+pub use expression::{Expression, Join, Project, Relation, Select, View};
 
-pub trait Tuple: Ord + Clone + Debug {}
-impl<T: Ord + Clone + Debug> Tuple for T {}
+pub trait Tuple: Ord + Clone {}
+impl<T: Ord + Clone> Tuple for T {}

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -1,0 +1,176 @@
+#[macro_export(loca_inner_macros)]
+macro_rules! relalg {
+    (select [$proj:expr] from ($($rel_exp:tt)*) $(where [$pred:expr])?) => {
+        $crate::relexp!(@select ($($rel_exp)*) @proj -> [$proj] $(@pred -> [$pred])?)
+    };
+    (select * from ($($rel_exp:tt)*) $(where [$pred:expr])?) => {
+        $crate::relexp!(@select ($($rel_exp)*) $(@pred -> [$pred])?)
+    };
+}
+
+#[macro_export(local_inner_macros)]
+macro_rules! relexp {
+    ($r:ident) => {
+        &$r
+    };
+    (select [$proj:expr] from ($($rel_exp:tt)*) $(where [$pred:expr])?) => {
+        $crate::relexp!(@select ($($rel_exp)*) @proj -> [$proj] $(@pred -> [$pred])?)
+    };
+    (select * from ($($rel_exp:tt)*) $(where [$pred:expr])?) => {
+        $crate::relexp!(@select ($($rel_exp)*) $(@pred -> [$pred])?)
+    };
+    (($($left:tt)*) join ($($right:tt)*) on [$mapper:expr]) => {
+        $crate::relexp!(@join ($($left)*) ($($right)*) @mapper -> [$mapper])
+    };
+    (@select ($($rel_exp:tt)*) @proj -> [$proj:expr] @pred -> [$pred:expr]) => {{
+        let rel_exp = $crate::relexp!($($rel_exp)*);
+        let sel_exp = $crate::Select::new(&rel_exp, $pred);
+        $crate::Project::new(&sel_exp, $proj)
+    }};
+    (@select ($($rel_exp:tt)*) @proj -> [$proj:expr]) => {{
+        let rel_exp = $crate::relexp!($($rel_exp)*);
+        $crate::Project::new(&rel_exp, $proj)
+    }};
+    (@select ($($rel_exp:tt)*) @pred -> [$pred:expr]) => {{
+        let rel_exp = $crate::relexp!($($rel_exp)*);
+        $crate::Select::new(&rel_exp, $pred)
+    }};
+    (@select ($($rel_exp:tt)*)) => {{
+        $crate::relexp!($($rel_exp)*)
+    }};
+    (@join ($($left:tt)*) ($($right:tt)*) @mapper -> [$mapper:expr]) => {{
+        let left = $crate::relexp!($($left)*);
+        let right = $crate::relexp!($($right)*);
+       $crate::Join::new(&left, &right, $mapper)
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{relalg, relexp};
+    use crate::{Database, Expression, Tuples};
+
+    #[test]
+    fn test_relalg() {
+        {
+            let mut database = Database::new();
+            let r = database.new_relation::<i32>("r");
+            let exp = relalg!(select * from (r) where [|t| t % 2 == 0]);
+            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
+            let result = exp.evaluate(&database).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![2, 4]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.new_relation::<i32>("r");
+            let exp = relalg!(select * from
+                                 (select * from (r) where [|&t| t > 2])
+                where [|t| t % 2 == 0]);
+            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
+            let result = exp.evaluate(&database).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![4]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.new_relation::<i32>("r");
+            let exp = relalg!(select [|t| t + 1] from
+                                 (select * from (r) where [|&t| t > 2]));
+            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
+            let result = exp.evaluate(&database).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![4, 5]), result);
+        }
+    }
+
+    #[test]
+    fn test_relexp() {
+        {
+            let mut database = Database::new();
+            let r = database.new_relation::<i32>("r");
+            let exp = relexp!(r);
+            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
+            let result = exp.evaluate(&database).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![1, 2, 3, 4]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.new_relation::<i32>("r");
+            let exp = relexp!(select * from (r) where [|t| t % 2 == 0]);
+            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
+            let result = exp.evaluate(&database).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![2, 4]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.new_relation::<i32>("r");
+            let exp = relexp!(select * from
+                                 (select * from (r) where [|&t| t > 2])
+                where [|t| t % 2 == 0]);
+            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
+            let result = exp.evaluate(&database).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![4]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.new_relation::<i32>("r");
+            let exp = relexp!(select [|t| t + 1] from (r));
+            r.insert(vec![3, 4, 5, 6].into(), &database).unwrap();
+            let result = exp.evaluate(&database).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![4, 5, 6, 7]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.new_relation::<i32>("r");
+            let exp = relexp!(select [|t| t + 1] from
+                                 (select * from (r) where [|&t| t > 2]));
+            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
+            let result = exp.evaluate(&database).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![4, 5]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.new_relation::<i32>("r");
+            let exp = relexp!(select * from(r));
+            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
+            let result = exp.evaluate(&database).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![1, 2, 3, 4]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.new_relation::<(i32, String)>("r");
+            let s = database.new_relation::<(i32, String)>("s");
+            let exp = relexp!((r) join (s) on [|_, x, y| {
+                let mut s = x.clone(); s.push_str(y); s
+            }]);
+            r.insert(
+                vec![
+                    (1, "a".to_string()),
+                    (2, "b".to_string()),
+                    (1, "a".to_string()),
+                    (4, "b".to_string()),
+                ]
+                .into(),
+                &database,
+            )
+            .unwrap();
+            s.insert(
+                vec![(1, "x".to_string()), (2, "y".to_string())].into(),
+                &database,
+            )
+            .unwrap();
+            let result = exp.evaluate(&database).unwrap();
+            assert_eq!(
+                Tuples::from(vec!["ax".to_string(), "by".to_string()]),
+                result
+            );
+        }
+        {
+            let mut database = Database::new();
+            let r = database.new_relation::<i32>("r");
+            let v = database.new_view(&r);
+            let exp = relexp!(select * from(v));
+            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
+            let result = exp.evaluate(&database).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![1, 2, 3, 4]), result);
+        }
+    }
+}


### PR DESCRIPTION
adds `relalg!` (and `relexp!`) macro for SQL like querying
(autocorrect keeps correcting "relalg" to "really" and "relexp" to "relax" 🙄)