### PR TITLE
major evaluation refactoring

### DIFF
--- a/core/examples/family_tree.rs
+++ b/core/examples/family_tree.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use relalg::{relalg, Database, Expression};
+use relalg::{relalg, Database};
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct Person {
@@ -60,7 +60,7 @@ fn main() -> Result<()> {
         )
     };
 
-    let names = fathers_name.evaluate(&family);
+    let names = family.evaluate(&fathers_name);
 
     for name in names.iter() {
         println!("{:?}", name);

--- a/core/src/database/elements.rs
+++ b/core/src/database/elements.rs
@@ -1,0 +1,41 @@
+use super::{RelationRef, ViewRef};
+use crate::{expression::Visitor, Tuple};
+
+pub struct Elements {
+    relations: Vec<RelationRef>,
+    views: Vec<ViewRef>,
+}
+
+impl Elements {
+    pub fn new() -> Self {
+        Self {
+            relations: Vec::new(),
+            views: Vec::new(),
+        }
+    }
+
+    pub fn relations(&self) -> &Vec<RelationRef> {
+        &self.relations
+    }
+
+    pub fn views(&self) -> &Vec<ViewRef> {
+        &self.views
+    }
+}
+
+impl Visitor for Elements {
+    fn visit_relation<T>(&mut self, relation: &crate::Relation<T>)
+    where
+        T: Tuple,
+    {
+        self.relations.push(relation.name.clone());
+    }
+
+    fn visit_view<T, E>(&mut self, view: &crate::View<T, E>)
+    where
+        T: crate::Tuple,
+        E: crate::Expression<T>,
+    {
+        self.views.push(view.reference.clone());
+    }
+}

--- a/core/src/database/evaluate.rs
+++ b/core/src/database/evaluate.rs
@@ -1,0 +1,327 @@
+use super::{elements::Elements, Database, Tuples};
+use crate::{
+    expression::{Collector, ListCollector},
+    tools::join_helper,
+    tools::project_helper,
+    Expression, Join, Project, Relation, Select, Tuple, View,
+};
+use anyhow::Result;
+
+pub(crate) struct Recent<'d>(pub &'d Database);
+
+impl<'d> Collector for Recent<'d> {
+    fn collect_relation<T>(&self, relation: &Relation<T>) -> Result<Tuples<T>>
+    where
+        T: Tuple,
+    {
+        let table = self.0.relation_instance(relation)?;
+        Ok(table.recent.borrow().clone())
+    }
+
+    fn collect_select<T, E>(&self, select: &Select<T, E>) -> Result<Tuples<T>>
+    where
+        T: Tuple,
+        E: Expression<T>,
+    {
+        let mut result = Vec::new();
+        let recent = select.expression().collect(self)?;
+        let predicate = &mut (*select.predicate().borrow_mut());
+        for tuple in &recent[..] {
+            if predicate(tuple) {
+                result.push(tuple.clone());
+            }
+        }
+        Ok(result.into())
+    }
+
+    fn collect_project<S, T, E>(&self, project: &Project<S, T, E>) -> Result<Tuples<T>>
+    where
+        T: Tuple,
+        S: Tuple,
+        E: Expression<S>,
+    {
+        let mut result = Vec::new();
+        let recent = project.expression().collect(self)?;
+        let mapper = &mut (*project.mapper().borrow_mut());
+        project_helper(&recent, |t| result.push(mapper(t)));
+        Ok(result.into())
+    }
+
+    fn collect_join<K, L, R, Left, Right, T>(
+        &self,
+        join: &crate::Join<K, L, R, Left, Right, T>,
+    ) -> Result<Tuples<T>>
+    where
+        K: Tuple,
+        L: Tuple,
+        R: Tuple,
+        T: Tuple,
+        Left: Expression<(K, L)>,
+        Right: Expression<(K, R)>,
+    {
+        let mut result = Vec::new();
+        let stable = Stable(self.0);
+
+        let left_recent = join.left().collect(self)?;
+        let right_recent = join.right().collect(self)?;
+
+        let left_stable = join.left().collect_list(&stable)?;
+        let right_stable = join.right().collect_list(&stable)?;
+
+        let mapper = &mut (*join.mapper().borrow_mut());
+
+        for left_batch in left_stable.iter() {
+            join_helper(&left_batch, &right_recent, |k, v1, v2| {
+                result.push(mapper(k, v1, v2))
+            });
+        }
+
+        for right_batch in right_stable.iter() {
+            join_helper(&left_recent, &right_batch, |k, v1, v2| {
+                result.push(mapper(k, v1, v2))
+            });
+        }
+
+        join_helper(&left_recent, &right_recent, |k, v1, v2| {
+            result.push(mapper(k, v1, v2))
+        });
+
+        Ok(result.into())
+    }
+
+    fn collect_view<T, E>(&self, view: &View<T, E>) -> Result<Tuples<T>>
+    where
+        T: Tuple,
+        E: Expression<T> + 'static,
+    {
+        let table = self.0.view_instance(view)?;
+        Ok(table.recent.borrow().clone())
+    }
+}
+
+pub(crate) struct Stable<'d>(&'d Database);
+
+impl<'d> ListCollector for Stable<'d> {
+    fn collect_relation<T>(&self, relation: &Relation<T>) -> Result<Vec<Tuples<T>>>
+    where
+        T: Tuple,
+    {
+        let mut result = Vec::<Tuples<T>>::new();
+        let table = self.0.relation_instance(&relation)?;
+        for batch in table.stable.borrow().iter() {
+            result.push(batch.clone());
+        }
+        Ok(result)
+    }
+
+    fn collect_select<T, E>(&self, select: &Select<T, E>) -> Result<Vec<Tuples<T>>>
+    where
+        T: Tuple,
+        E: Expression<T>,
+    {
+        let mut result = Vec::<Tuples<T>>::new();
+        let stable = select.expression().collect_list(self)?;
+        let predicate = &mut (*select.predicate().borrow_mut());
+        for batch in stable.iter() {
+            let mut tuples = Vec::new();
+            for tuple in &batch[..] {
+                if predicate(tuple) {
+                    tuples.push(tuple.clone());
+                }
+            }
+            result.push(tuples.into());
+        }
+        Ok(result)
+    }
+
+    fn collect_project<S, T, E>(&self, project: &Project<S, T, E>) -> Result<Vec<Tuples<T>>>
+    where
+        T: Tuple,
+        S: Tuple,
+        E: Expression<S>,
+    {
+        let mut result = Vec::<Tuples<T>>::new();
+        let stable = project.expression().collect_list(self)?;
+        let mapper = &mut (*project.mapper().borrow_mut());
+        for batch in stable.iter() {
+            let mut tuples = Vec::new();
+            project_helper(&batch, |t| tuples.push(mapper(t)));
+            result.push(tuples.into());
+        }
+        Ok(result)
+    }
+
+    fn collect_join<K, L, R, Left, Right, T>(
+        &self,
+        join: &crate::Join<K, L, R, Left, Right, T>,
+    ) -> Result<Vec<Tuples<T>>>
+    where
+        K: Tuple,
+        L: Tuple,
+        R: Tuple,
+        T: Tuple,
+        Left: Expression<(K, L)>,
+        Right: Expression<(K, R)>,
+    {
+        let mut result = Vec::<Tuples<T>>::new();
+        let left = join.left().collect_list(self)?;
+        let right = join.right().collect_list(self)?;
+
+        let mapper = &mut (*join.mapper().borrow_mut());
+        for left_batch in left.iter() {
+            let mut tuples = Vec::new();
+            for right_batch in right.iter() {
+                join_helper(&left_batch, &right_batch, |k, v1, v2| {
+                    tuples.push(mapper(k, v1, v2))
+                });
+            }
+            result.push(tuples.into());
+        }
+        Ok(result)
+    }
+
+    fn collect_view<T, E>(&self, view: &View<T, E>) -> Result<Vec<Tuples<T>>>
+    where
+        T: Tuple,
+        E: Expression<T> + 'static,
+    {
+        let mut result = Vec::<Tuples<T>>::new();
+        let table = self.0.view_instance(&view)?;
+        for batch in table.stable.borrow().iter() {
+            result.push(batch.clone());
+        }
+        Ok(result)
+    }
+}
+
+pub(crate) struct Evaluator<'d>(pub &'d Database);
+
+impl<'d> Collector for Evaluator<'d> {
+    fn collect_relation<T>(&self, relation: &Relation<T>) -> Result<Tuples<T>>
+    where
+        T: Tuple,
+    {
+        self.0.recalculate_relation(&relation.name)?;
+        let table = self.0.relation_instance(&relation)?;
+        assert!(table.recent.borrow().is_empty());
+        assert!(table.to_add.borrow().is_empty());
+
+        let recent = Recent(self.0);
+        let stable = Stable(self.0);
+
+        let mut result = relation.collect(&recent)?;
+        for batch in relation.collect_list(&stable)? {
+            result = result.merge(batch);
+        }
+
+        Ok(result)
+    }
+
+    fn collect_select<T, E>(&self, select: &Select<T, E>) -> Result<Tuples<T>>
+    where
+        T: Tuple,
+        E: Expression<T>,
+    {
+        let mut elements = crate::database::elements::Elements::new();
+        select.visit(&mut elements);
+
+        for r in elements.relations() {
+            self.0.recalculate_relation(&r)?;
+        }
+
+        for r in elements.views() {
+            self.0.recalculate_view(&r)?;
+        }
+
+        let recent = Recent(self.0);
+        let stable = Stable(self.0);
+
+        let mut result = select.collect(&recent)?;
+        for batch in select.collect_list(&stable)? {
+            result = result.merge(batch);
+        }
+        Ok(result)
+    }
+
+    fn collect_project<S, T, E>(&self, project: &Project<S, T, E>) -> Result<Tuples<T>>
+    where
+        T: Tuple,
+        S: Tuple,
+        E: Expression<S>,
+    {
+        let mut elements = crate::database::elements::Elements::new();
+        project.visit(&mut elements);
+
+        for r in elements.relations() {
+            self.0.recalculate_relation(&r)?;
+        }
+
+        for r in elements.views() {
+            self.0.recalculate_view(&r)?;
+        }
+
+        let recent = Recent(self.0);
+        let stable = Stable(self.0);
+
+        let mut result = project.collect(&recent)?;
+        for batch in project.collect_list(&stable)? {
+            result = result.merge(batch);
+        }
+        Ok(result)
+    }
+
+    fn collect_join<K, L, R, Left, Right, T>(
+        &self,
+        join: &Join<K, L, R, Left, Right, T>,
+    ) -> Result<Tuples<T>>
+    where
+        K: Tuple,
+        L: Tuple,
+        R: Tuple,
+        T: Tuple,
+        Left: Expression<(K, L)>,
+        Right: Expression<(K, R)>,
+    {
+        let mut elements = Elements::new();
+        join.visit(&mut elements);
+
+        for r in elements.relations() {
+            self.0.recalculate_relation(&r)?;
+        }
+
+        for r in elements.views() {
+            self.0.recalculate_view(&r)?;
+        }
+
+        let recent = Recent(self.0);
+        let stable = Stable(self.0);
+
+        let mut result = join.collect(&recent)?;
+        for batch in join.collect_list(&stable)? {
+            result = result.merge(batch);
+        }
+
+        Ok(result)
+    }
+
+    fn collect_view<T, E>(&self, view: &View<T, E>) -> Result<Tuples<T>>
+    where
+        T: Tuple,
+        E: Expression<T> + 'static,
+    {
+        self.0.recalculate_view(&view.reference)?;
+        let table = self.0.view_instance(view)?;
+        assert!(table.recent.borrow().is_empty());
+        assert!(table.to_add.borrow().is_empty());
+
+        let recent = Recent(self.0);
+        let stable = Stable(self.0);
+
+        let mut result = view.collect(&recent)?;
+        for batch in view.collect_list(&stable)? {
+            result = result.merge(batch);
+        }
+
+        Ok(result)
+    }
+}

--- a/core/src/expression.rs
+++ b/core/src/expression.rs
@@ -1,738 +1,192 @@
-use crate::{
-    database::{Database, Tuples, ViewRef},
-    tools::{join_helper, project_helper},
-    Tuple,
-};
+mod join;
+mod project;
+mod relation;
+mod select;
+mod view;
+
+use crate::{database::Tuples, Tuple};
 use anyhow::Result;
-use std::{cell::RefCell, marker::PhantomData, rc::Rc};
 
-pub trait Expression<T: Tuple> {
-    fn evaluate(&self, db: &Database) -> Result<Tuples<T>>;
+pub use join::Join;
+pub use project::Project;
+pub use relation::Relation;
+pub use select::Select;
+pub use view::View;
 
-    fn recent_tuples(&self, db: &Database) -> Result<Tuples<T>>;
+pub trait Expression<T: Tuple>: Clone {
+    fn visit<V>(&self, visitor: &mut V)
+    where
+        V: Visitor;
 
-    fn stable_tuples(&self, db: &Database) -> Result<Vec<Tuples<T>>>;
+    fn collect<C>(&self, collector: &C) -> Result<Tuples<T>>
+    where
+        C: Collector;
 
-    fn duplicate(&self) -> Box<dyn Expression<T>>;
+    fn collect_list<C>(&self, collector: &C) -> Result<Vec<Tuples<T>>>
+    where
+        C: ListCollector;
 }
 
-impl<T: Tuple, E: Expression<T>> Expression<T> for &E {
-    fn evaluate(&self, db: &Database) -> Result<Tuples<T>> {
-        (*self).evaluate(db)
-    }
-    fn recent_tuples(&self, db: &Database) -> Result<Tuples<T>> {
-        (*self).recent_tuples(db)
-    }
-    fn stable_tuples(&self, db: &Database) -> Result<Vec<Tuples<T>>> {
-        (*self).stable_tuples(db)
-    }
-    fn duplicate(&self) -> Box<dyn Expression<T>> {
-        (*self).duplicate()
-    }
-}
-
-impl<T: Tuple> Expression<T> for Box<dyn Expression<T>> {
-    fn evaluate(&self, db: &Database) -> Result<Tuples<T>> {
-        (**self).evaluate(db)
-    }
-    fn recent_tuples(&self, db: &Database) -> Result<Tuples<T>> {
-        (**self).recent_tuples(db)
-    }
-    fn stable_tuples(&self, db: &Database) -> Result<Vec<Tuples<T>>> {
-        (**self).stable_tuples(db)
-    }
-    fn duplicate(&self) -> Box<dyn Expression<T>> {
-        (**self).duplicate()
-    }
-}
-
-#[derive(Clone)]
-pub struct Relation<T: Tuple> {
-    pub(crate) name: String,
-    _phantom: PhantomData<T>,
-}
-
-impl<T: Tuple + 'static> Relation<T> {
-    pub fn new(name: &str) -> Self {
-        Self {
-            name: name.to_string(),
-            _phantom: PhantomData,
-        }
+pub trait Visitor: Sized {
+    fn visit_relation<T>(&mut self, relation: &Relation<T>)
+    where
+        T: Tuple,
+    {
+        walk_relation(self, relation)
     }
 
-    pub fn insert(&self, tuples: Tuples<T>, db: &Database) -> Result<()> {
-        let relation = db.relation_instance(&self)?;
-        relation.insert(tuples);
-        Ok(())
-    }
-}
-
-impl<T: Tuple + 'static> Expression<T> for Relation<T> {
-    fn evaluate(&self, db: &Database) -> Result<Tuples<T>> {
-        db.recalculate_views()?;
-        let table = db.relation_instance(&self)?;
-        assert!(table.recent.borrow().is_empty());
-        assert!(table.to_add.borrow().is_empty());
-
-        let mut result = self.recent_tuples(&db)?;
-        for batch in self.stable_tuples(&db)? {
-            result = result.merge(batch);
-        }
-
-        Ok(result)
+    fn visit_select<T, E>(&mut self, select: &Select<T, E>)
+    where
+        T: Tuple,
+        E: Expression<T>,
+    {
+        walk_select(self, select);
     }
 
-    fn recent_tuples(&self, db: &Database) -> Result<Tuples<T>> {
-        let table = db.relation_instance(&self)?;
-        Ok(table.recent.borrow().clone())
+    fn visit_project<S, T, E>(&mut self, project: &Project<S, T, E>)
+    where
+        T: Tuple,
+        S: Tuple,
+        E: Expression<S>,
+    {
+        walk_project(self, project);
     }
 
-    fn stable_tuples(&self, db: &Database) -> Result<Vec<Tuples<T>>> {
-        let mut result = Vec::<Tuples<T>>::new();
-        let table = db.relation_instance(&self)?;
-        for batch in table.stable.borrow().iter() {
-            result.push(batch.clone());
-        }
-        Ok(result)
+    fn visit_join<K, L, R, Left, Right, T>(&mut self, join: &Join<K, L, R, Left, Right, T>)
+    where
+        K: Tuple,
+        L: Tuple,
+        R: Tuple,
+        T: Tuple,
+        Left: Expression<(K, L)>,
+        Right: Expression<(K, R)>,
+    {
+        walk_join(self, join);
     }
 
-    fn duplicate(&self) -> Box<dyn Expression<T>> {
-        Box::new(Self::new(&self.name))
+    fn visit_view<T, E>(&mut self, view: &View<T, E>)
+    where
+        T: Tuple,
+        E: Expression<T>,
+    {
+        walk_view(self, view);
     }
 }
 
-pub struct Select<T>
+pub fn walk_relation<T, V>(_: &mut V, _: &Relation<T>)
 where
     T: Tuple,
+    V: Visitor,
 {
-    expression: Box<dyn Expression<T>>,
-    predicate: Rc<RefCell<dyn FnMut(&T) -> bool>>,
+    // nothing to do
 }
 
-impl<T> Select<T>
+pub fn walk_select<T, E, V>(visitor: &mut V, select: &Select<T, E>)
 where
     T: Tuple,
+    E: Expression<T>,
+    V: Visitor,
 {
-    pub fn new(
-        expression: &impl Expression<T>,
-        predicate: impl FnMut(&T) -> bool + 'static,
-    ) -> Self {
-        Self {
-            expression: expression.duplicate(),
-            predicate: Rc::new(RefCell::new(predicate)),
-        }
-    }
+    select.expression().visit(visitor);
 }
 
-impl<T> Expression<T> for Select<T>
+pub fn walk_project<S, T, E, V>(visitor: &mut V, project: &Project<S, T, E>)
 where
-    T: Tuple + 'static,
-{
-    fn evaluate(&self, db: &Database) -> Result<Tuples<T>> {
-        db.recalculate_views()?;
-        let mut result = self.recent_tuples(&db)?;
-        for batch in self.stable_tuples(&db)? {
-            result = result.merge(batch);
-        }
-        Ok(result)
-    }
-    fn recent_tuples(&self, db: &Database) -> Result<Tuples<T>> {
-        let mut result = Vec::new();
-        let recent = self.expression.recent_tuples(&db)?;
-        let predicate = &mut (*self.predicate.borrow_mut());
-        for tuple in &recent[..] {
-            if predicate(tuple) {
-                result.push(tuple.clone());
-            }
-        }
-        Ok(result.into())
-    }
-    fn stable_tuples(&self, db: &Database) -> Result<Vec<Tuples<T>>> {
-        let mut result = Vec::<Tuples<T>>::new();
-        let stable = self.expression.stable_tuples(&db)?;
-        let predicate = &mut (*self.predicate.borrow_mut());
-        for batch in stable.iter() {
-            let mut tuples = Vec::new();
-            for tuple in &batch[..] {
-                if predicate(tuple) {
-                    tuples.push(tuple.clone());
-                }
-            }
-            result.push(tuples.into());
-        }
-        Ok(result)
-    }
-    fn duplicate(&self) -> Box<dyn Expression<T>> {
-        Box::new(Self {
-            expression: self.expression.duplicate(),
-            predicate: self.predicate.clone(),
-        })
-    }
-}
-
-pub struct Project<S, T>
-where
+    T: Tuple,
     S: Tuple,
-    T: Tuple,
+    E: Expression<S>,
+    V: Visitor,
 {
-    expression: Box<dyn Expression<S>>,
-    mapper: Rc<RefCell<dyn FnMut(&S) -> T>>,
+    project.expression().visit(visitor);
 }
 
-impl<S, T> Project<S, T>
-where
-    S: Tuple,
-    T: Tuple,
-{
-    pub fn new(expression: &impl Expression<S>, project: impl FnMut(&S) -> T + 'static) -> Self {
-        Self {
-            expression: expression.duplicate(),
-            mapper: Rc::new(RefCell::new(project)),
-        }
-    }
-}
-
-impl<S, T> Expression<T> for Project<S, T>
-where
-    S: Tuple + 'static,
-    T: Tuple + 'static,
-{
-    fn evaluate(&self, db: &Database) -> Result<Tuples<T>> {
-        db.recalculate_views()?;
-        let mut result = self.recent_tuples(&db)?;
-        for batch in self.stable_tuples(&db)? {
-            result = result.merge(batch);
-        }
-        Ok(result)
-    }
-    fn recent_tuples(&self, db: &Database) -> Result<Tuples<T>> {
-        let mut result = Vec::new();
-        let recent = self.expression.recent_tuples(&db)?;
-        let mapper = &mut (*self.mapper.borrow_mut());
-        project_helper(&recent, |t| result.push(mapper(t)));
-        Ok(result.into())
-    }
-    fn stable_tuples(&self, db: &Database) -> Result<Vec<Tuples<T>>> {
-        let mut result = Vec::<Tuples<T>>::new();
-        let stable = self.expression.stable_tuples(&db)?;
-        let mapper = &mut (*self.mapper.borrow_mut());
-        for batch in stable.iter() {
-            let mut tuples = Vec::new();
-            project_helper(&batch, |t| tuples.push(mapper(t)));
-            result.push(tuples.into());
-        }
-        Ok(result)
-    }
-    fn duplicate(&self) -> Box<dyn Expression<T>> {
-        Box::new(Self {
-            expression: self.expression.duplicate(),
-            mapper: self.mapper.clone(),
-        })
-    }
-}
-
-pub struct Join<K, L, R, T>
+pub fn walk_join<K, L, R, Left, Right, T, V>(visitor: &mut V, join: &Join<K, L, R, Left, Right, T>)
 where
     K: Tuple,
     L: Tuple,
     R: Tuple,
     T: Tuple,
+    Left: Expression<(K, L)>,
+    Right: Expression<(K, R)>,
+    V: Visitor,
 {
-    left: Box<dyn Expression<(K, L)>>,
-    right: Box<dyn Expression<(K, R)>>,
-    mapper: Rc<RefCell<dyn FnMut(&K, &L, &R) -> T>>,
+    join.left().visit(visitor);
+    join.right().visit(visitor);
 }
 
-impl<K, L, R, T> Join<K, L, R, T>
+pub fn walk_view<T, E, V>(_: &mut V, _: &View<T, E>)
 where
-    K: Tuple,
-    L: Tuple,
-    R: Tuple,
     T: Tuple,
+    E: Expression<T>,
+    V: Visitor,
 {
-    pub fn new(
-        left: &impl Expression<(K, L)>,
-        right: &impl Expression<(K, R)>,
-        project: impl FnMut(&K, &L, &R) -> T + 'static,
-    ) -> Self {
-        Self {
-            left: left.duplicate(),
-            right: right.duplicate(),
-            mapper: Rc::new(RefCell::new(project)),
-        }
-    }
+    // nothing to do
 }
 
-impl<K, L, R, T> Expression<T> for Join<K, L, R, T>
-where
-    K: Tuple + 'static,
-    L: Tuple + 'static,
-    R: Tuple + 'static,
-    T: Tuple + 'static,
-{
-    fn evaluate(&self, db: &Database) -> Result<Tuples<T>> {
-        db.recalculate_views()?;
+pub trait Collector {
+    fn collect_relation<T>(&self, relation: &Relation<T>) -> Result<Tuples<T>>
+    where
+        T: Tuple;
 
-        let mut result = self.recent_tuples(&db)?;
-        for batch in self.stable_tuples(&db)? {
-            result = result.merge(batch);
-        }
+    fn collect_select<T, E>(&self, select: &Select<T, E>) -> Result<Tuples<T>>
+    where
+        T: Tuple,
+        E: Expression<T>;
 
-        Ok(result)
-    }
-    fn recent_tuples(&self, db: &Database) -> Result<Tuples<T>> {
-        let mut result = Vec::new();
-        let left_recent = self.left.recent_tuples(&db)?;
-        let left_stable = self.left.stable_tuples(&db)?;
-        let right_recent = self.right.recent_tuples(&db)?;
-        let right_stable = self.right.stable_tuples(&db)?;
+    fn collect_project<S, T, E>(&self, project: &Project<S, T, E>) -> Result<Tuples<T>>
+    where
+        T: Tuple,
+        S: Tuple,
+        E: Expression<S>;
 
-        let mapper = &mut (*self.mapper.borrow_mut());
+    fn collect_join<K, L, R, Left, Right, T>(
+        &self,
+        join: &Join<K, L, R, Left, Right, T>,
+    ) -> Result<Tuples<T>>
+    where
+        K: Tuple,
+        L: Tuple,
+        R: Tuple,
+        T: Tuple,
+        Left: Expression<(K, L)>,
+        Right: Expression<(K, R)>;
 
-        for left_batch in left_stable.iter() {
-            join_helper(&left_batch, &right_recent, |k, v1, v2| {
-                result.push(mapper(k, v1, v2))
-            });
-        }
-
-        for right_batch in right_stable.iter() {
-            join_helper(&left_recent, &right_batch, |k, v1, v2| {
-                result.push(mapper(k, v1, v2))
-            });
-        }
-
-        join_helper(&left_recent, &right_recent, |k, v1, v2| {
-            result.push(mapper(k, v1, v2))
-        });
-
-        Ok(result.into())
-    }
-    fn stable_tuples(&self, db: &Database) -> Result<Vec<Tuples<T>>> {
-        // TODO do not clone recent and stable recursively.
-        let mut result = Vec::<Tuples<T>>::new();
-        let left = self.left.stable_tuples(&db)?;
-        let right = self.right.stable_tuples(&db)?;
-
-        let mapper = &mut (*self.mapper.borrow_mut());
-        for left_batch in left.iter() {
-            let mut tuples = Vec::new();
-            for right_batch in right.iter() {
-                join_helper(&left_batch, &right_batch, |k, v1, v2| {
-                    tuples.push(mapper(k, v1, v2))
-                });
-            }
-            result.push(tuples.into());
-        }
-        Ok(result)
-    }
-    fn duplicate(&self) -> Box<dyn Expression<T>> {
-        Box::new(Self {
-            left: self.left.duplicate(),
-            right: self.right.duplicate(),
-            mapper: self.mapper.clone(),
-        })
-    }
+    fn collect_view<T, E>(&self, view: &View<T, E>) -> Result<Tuples<T>>
+    where
+        T: Tuple,
+        E: Expression<T> + 'static;
 }
 
-#[derive(Clone)]
-pub struct View<T: Tuple> {
-    pub(crate) reference: ViewRef,
-    _phantom: PhantomData<T>,
-}
+pub trait ListCollector {
+    fn collect_relation<T>(&self, relation: &Relation<T>) -> Result<Vec<Tuples<T>>>
+    where
+        T: Tuple;
 
-impl<T: Tuple + 'static> View<T> {
-    pub(crate) fn new(reference: ViewRef) -> Self {
-        Self {
-            reference,
-            _phantom: PhantomData,
-        }
-    }
-}
+    fn collect_select<T, E>(&self, select: &Select<T, E>) -> Result<Vec<Tuples<T>>>
+    where
+        T: Tuple,
+        E: Expression<T>;
 
-impl<T: Tuple + 'static> Expression<T> for View<T> {
-    fn evaluate(&self, db: &Database) -> Result<Tuples<T>> {
-        db.recalculate_views()?;
-        let table = db.view_instance(&self)?;
-        assert!(table.recent.borrow().is_empty());
-        assert!(table.to_add.borrow().is_empty());
+    fn collect_project<S, T, E>(&self, project: &Project<S, T, E>) -> Result<Vec<Tuples<T>>>
+    where
+        T: Tuple,
+        S: Tuple,
+        E: Expression<S>;
 
-        let mut result = self.recent_tuples(&db)?;
-        for batch in self.stable_tuples(&db)? {
-            result = result.merge(batch);
-        }
+    fn collect_join<K, L, R, Left, Right, T>(
+        &self,
+        join: &Join<K, L, R, Left, Right, T>,
+    ) -> Result<Vec<Tuples<T>>>
+    where
+        K: Tuple,
+        L: Tuple,
+        R: Tuple,
+        T: Tuple,
+        Left: Expression<(K, L)>,
+        Right: Expression<(K, R)>;
 
-        Ok(result)
-    }
-
-    fn recent_tuples(&self, db: &Database) -> Result<Tuples<T>> {
-        let table = db.view_instance(&self)?;
-        Ok(table.recent.borrow().clone())
-    }
-
-    fn stable_tuples(&self, db: &Database) -> Result<Vec<Tuples<T>>> {
-        let mut result = Vec::<Tuples<T>>::new();
-        let table = db.view_instance(&self)?;
-        for batch in table.stable.borrow().iter() {
-            result.push(batch.clone());
-        }
-        Ok(result)
-    }
-
-    fn duplicate(&self) -> Box<dyn Expression<T>> {
-        Box::new(Self::new(self.reference.clone()))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_new_relation() {
-        assert_eq!("a".to_string(), Relation::<i32>::new("a").name);
-    }
-
-    #[test]
-    fn test_insert_relation() {
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<i32>("r");
-            assert!(r.insert(vec![1, 2, 3].into(), &database).is_ok());
-            assert_eq!(
-                Tuples::<i32>::from(vec![1, 2, 3]),
-                database.relation_instance(&r).unwrap().to_add.borrow()[0]
-            );
-        }
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<i32>("r");
-            assert!(r.insert(vec![1, 2, 3].into(), &database).is_ok());
-            assert!(r.insert(vec![1, 4].into(), &database).is_ok());
-            assert_eq!(
-                Tuples::<i32>::from(vec![1, 2, 3]),
-                database.relation_instance(&r).unwrap().to_add.borrow()[0]
-            );
-            assert_eq!(
-                Tuples::<i32>::from(vec![1, 4]),
-                database.relation_instance(&r).unwrap().to_add.borrow()[1]
-            );
-        }
-        {
-            let database = Database::new();
-            let r = Database::new().add_relation("r"); // dummy database
-            assert!(r.insert(vec![1, 2, 3].into(), &database).is_err());
-        }
-    }
-
-    #[test]
-    fn test_duplicate_relation() {
-        let mut database = Database::new();
-        let r = database.add_relation::<i32>("r");
-        r.insert(vec![1, 2, 3].into(), &database).unwrap();
-        assert_eq!(
-            Tuples::<i32>::from(vec![1, 2, 3]),
-            r.duplicate().evaluate(&database).unwrap()
-        );
-    }
-
-    #[test]
-    fn test_duplicate_select() {
-        let mut database = Database::new();
-        let r = database.add_relation::<i32>("r");
-        r.insert(vec![1, 2, 3].into(), &database).unwrap();
-        let p = Select::new(&r, |&t| t % 2 == 1).duplicate();
-        assert_eq!(
-            Tuples::<i32>::from(vec![1, 3]),
-            p.evaluate(&database).unwrap()
-        );
-    }
-
-    #[test]
-    fn test_duplicate_project() {
-        let mut database = Database::new();
-        let r = database.add_relation::<i32>("r");
-        r.insert(vec![1, 2, 3].into(), &database).unwrap();
-        let p = Project::new(&r, |&t| t * 10).duplicate();
-        assert_eq!(
-            Tuples::<i32>::from(vec![10, 20, 30]),
-            p.evaluate(&database).unwrap()
-        );
-    }
-
-    #[test]
-    fn test_duplicate_join() {
-        let mut database = Database::new();
-        let r = database.add_relation::<(i32, i32)>("r");
-        let s = database.add_relation::<(i32, i32)>("s");
-        r.insert(vec![(1, 10)].into(), &database).unwrap();
-        s.insert(vec![(1, 100)].into(), &database).unwrap();
-        let v = Join::new(&r, &s, |_, &l, &r| (l, r)).duplicate();
-        assert_eq!(
-            Tuples::<(i32, i32)>::from(vec![(10, 100)]),
-            v.evaluate(&database).unwrap()
-        );
-    }
-
-    #[test]
-    fn test_duplicate_view() {
-        let mut database = Database::new();
-        let r = database.add_relation::<i32>("r");
-        let v = database.store_view(&r).duplicate();
-        r.insert(vec![1, 2, 3].into(), &database).unwrap();
-        assert_eq!(
-            Tuples::<i32>::from(vec![1, 2, 3]),
-            v.evaluate(&database).unwrap()
-        );
-    }
-
-    #[test]
-    fn test_evaluate_relation() {
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<i32>("r");
-            r.insert(vec![1, 2, 3].into(), &database).unwrap();
-            let result = r.evaluate(&database).unwrap();
-            assert_eq!(Tuples::<i32>::from(vec![1, 2, 3]), result);
-        }
-        {
-            let database = Database::new();
-            let mut dummy = Database::new();
-            let r = dummy.add_relation::<i32>("r");
-
-            assert!(r.evaluate(&database).is_err());
-        }
-    }
-
-    #[test]
-    fn test_evaluate_select() {
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<i32>("r");
-            let project = Select::new(&r, |t| t % 2 == 1);
-
-            let result = project.evaluate(&database).unwrap();
-            assert_eq!(Tuples::<i32>::from(vec![]), result);
-        }
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<i32>("r");
-            let select = Select::new(&r, |t| t % 2 == 0);
-            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
-
-            let result = select.evaluate(&database).unwrap();
-            assert_eq!(Tuples::<i32>::from(vec![2, 4]), result);
-        }
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<i32>("r");
-            let p1 = Select::new(&r, |t| t % 2 == 0);
-            let p2 = Select::new(&p1, |&t| t > 3);
-
-            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
-
-            let result = p2.evaluate(&database).unwrap();
-            assert_eq!(Tuples::<i32>::from(vec![4]), result);
-        }
-        {
-            let database = Database::new();
-            let mut dummy = Database::new();
-            let r = dummy.add_relation::<i32>("r");
-            let select = Select::new(&r, |&t| t > 1);
-            assert!(select.evaluate(&database).is_err());
-        }
-    }
-
-    #[test]
-    fn test_evaluate_project() {
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<i32>("r");
-            let project = Project::new(&r, |t| t * 10);
-
-            let result = project.evaluate(&database).unwrap();
-            assert_eq!(Tuples::<i32>::from(vec![]), result);
-        }
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<i32>("r");
-            let project = Project::new(&r, |t| t * 10);
-            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
-
-            let result = project.evaluate(&database).unwrap();
-            assert_eq!(Tuples::<i32>::from(vec![10, 20, 30, 40]), result);
-        }
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<i32>("r");
-            let p1 = Project::new(&r, |t| t * 10);
-            let p2 = Project::new(&p1, |t| t + 1);
-
-            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
-
-            let result = p2.evaluate(&database).unwrap();
-            assert_eq!(Tuples::<i32>::from(vec![11, 21, 31, 41]), result);
-        }
-        {
-            let database = Database::new();
-            let mut dummy = Database::new();
-            let r = dummy.add_relation::<i32>("r");
-            let project = Project::new(&r, |t| t + 1);
-            assert!(project.evaluate(&database).is_err());
-        }
-    }
-
-    #[test]
-    fn test_evaluate_join() {
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<(i32, i32)>("r");
-            let s = database.add_relation::<(i32, i32)>("s");
-            let join = Join::new(&r, &s, |_, &l, &r| (l, r));
-
-            let result = join.evaluate(&database).unwrap();
-            assert_eq!(Tuples::<(i32, i32)>::from(vec![]), result);
-        }
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<(i32, i32)>("r");
-            let s = database.add_relation::<(i32, i32)>("s");
-            let join = Join::new(&r, &s, |_, &l, &r| (l, r));
-            r.insert(vec![(1, 4), (2, 2), (1, 3)].into(), &database)
-                .unwrap();
-            let result = join.evaluate(&database).unwrap();
-            assert_eq!(Tuples::<(i32, i32)>::from(vec![]), result);
-        }
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<(i32, i32)>("r");
-            let s = database.add_relation::<(i32, i32)>("s");
-            let join = Join::new(&r, &s, |_, &l, &r| (l, r));
-            s.insert(vec![(1, 5), (3, 2), (1, 6)].into(), &database)
-                .unwrap();
-
-            let result = join.evaluate(&database).unwrap();
-            assert_eq!(Tuples::<(i32, i32)>::from(vec![]), result);
-        }
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<(i32, i32)>("r");
-            let s = database.add_relation::<(i32, i32)>("s");
-            let join = Join::new(&r, &s, |_, &l, &r| (l, r));
-            r.insert(vec![(1, 4), (2, 2), (1, 3)].into(), &database)
-                .unwrap();
-            s.insert(vec![(1, 5), (3, 2), (1, 6)].into(), &database)
-                .unwrap();
-
-            let result = join.evaluate(&database).unwrap();
-            assert_eq!(
-                Tuples::<(i32, i32)>::from(vec![(3, 5), (3, 6), (4, 5), (4, 6)]),
-                result
-            );
-        }
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<(i32, i32)>("r");
-            let s = database.add_relation::<(i32, i32)>("s");
-            let t = database.add_relation::<(i32, i32)>("t");
-            let r_s = Join::new(&r, &s, |_, &l, &r| (l, r));
-            let r_s_t = Join::new(&r_s, &t, |_, _, &r| r);
-
-            r.insert(vec![(1, 4), (2, 2), (1, 3)].into(), &database)
-                .unwrap();
-            s.insert(vec![(1, 5), (3, 2), (1, 6)].into(), &database)
-                .unwrap();
-            t.insert(vec![(1, 40), (2, 41), (3, 42), (4, 43)].into(), &database)
-                .unwrap();
-
-            let result = r_s_t.evaluate(&database).unwrap();
-            assert_eq!(Tuples::<i32>::from(vec![42, 43]), result);
-        }
-        {
-            let mut database = Database::new();
-            let mut dummy = Database::new();
-            let r = database.add_relation::<(i32, i32)>("r");
-            let s = dummy.add_relation::<(i32, i32)>("s");
-            let join = Join::new(&r, &s, |_, &l, &r| (l, r));
-            assert!(join.evaluate(&database).is_err());
-        }
-    }
-
-    #[test]
-    fn test_evaluate_view() {
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<i32>("r");
-            let v = database.store_view(&r);
-            r.insert(vec![1, 2, 3].into(), &database).unwrap();
-            let result = v.evaluate(&database).unwrap();
-            assert_eq!(Tuples::<i32>::from(vec![1, 2, 3]), result);
-        }
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<i32>("r");
-            let v_1 = database.store_view(&r);
-            let v_2 = database.store_view(&v_1);
-            let v_3 = database.store_view(&v_2);
-            r.insert(vec![1, 2, 3].into(), &database).unwrap();
-            let result = v_3.evaluate(&database).unwrap();
-            assert_eq!(Tuples::<i32>::from(vec![1, 2, 3]), result);
-        }
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<(i32, i32)>("r");
-            let s = database.add_relation::<(i32, i32)>("s");
-            let r_s = Join::new(&r, &s, |_, &l, &r| (l, r));
-            let view = database.store_view(&r_s);
-
-            r.insert(vec![(1, 4), (2, 2), (1, 3)].into(), &database)
-                .unwrap();
-            s.insert(vec![(1, 5), (3, 2), (1, 6)].into(), &database)
-                .unwrap();
-
-            let result = view.evaluate(&database).unwrap();
-            assert_eq!(
-                Tuples::<(i32, i32)>::from(vec![(3, 5), (3, 6), (4, 5), (4, 6)]),
-                result
-            );
-        }
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<(i32, i32)>("r");
-            let s = database.add_relation::<(i32, i32)>("s");
-            let r_s = Join::new(&r, &s, |_, &l, &r| (l, r));
-            let view = database.store_view(&r_s);
-
-            r.insert(vec![(1, 4), (2, 2), (1, 3)].into(), &database)
-                .unwrap();
-            s.insert(vec![(1, 5), (3, 2), (1, 6)].into(), &database)
-                .unwrap();
-
-            view.evaluate(&database).unwrap();
-            s.insert(vec![(1, 7)].into(), &database).unwrap();
-            let result = view.evaluate(&database).unwrap();
-            assert_eq!(
-                Tuples::<(i32, i32)>::from(vec![(3, 5), (3, 6), (3, 7), (4, 5), (4, 6), (4, 7)]),
-                result
-            );
-        }
-        {
-            let mut database = Database::new();
-            let r = database.add_relation::<(i32, i32)>("r");
-            let s = database.add_relation::<(i32, i32)>("s");
-            let t = database.add_relation::<(i32, i32)>("t");
-            let r_s = Join::new(&r, &s, |_, &l, &r| (l, r));
-            let r_s_t = Join::new(&r_s, &t, |_, _, &r| r);
-            let view = database.store_view(&r_s_t);
-
-            r.insert(vec![(1, 4), (2, 2), (1, 3)].into(), &database)
-                .unwrap();
-            s.insert(vec![(1, 5), (3, 2), (1, 6)].into(), &database)
-                .unwrap();
-            t.insert(vec![(1, 40), (2, 41), (3, 42), (4, 43)].into(), &database)
-                .unwrap();
-
-            let result = view.evaluate(&database).unwrap();
-            assert_eq!(Tuples::<i32>::from(vec![42, 43]), result);
-        }
-    }
+    fn collect_view<T, E>(&self, view: &View<T, E>) -> Result<Vec<Tuples<T>>>
+    where
+        T: Tuple,
+        E: Expression<T> + 'static;
 }

--- a/core/src/expression/join.rs
+++ b/core/src/expression/join.rs
@@ -1,0 +1,176 @@
+use super::{Expression, Visitor};
+use crate::{database::Tuples, Tuple};
+use anyhow::Result;
+use std::{cell::RefCell, rc::Rc};
+
+#[derive(Clone)]
+pub struct Join<K, L, R, Left, Right, T>
+where
+    K: Tuple,
+    L: Tuple,
+    R: Tuple,
+    T: Tuple,
+    Left: Expression<(K, L)>,
+    Right: Expression<(K, R)>,
+{
+    left: Left,
+    right: Right,
+    mapper: Rc<RefCell<dyn FnMut(&K, &L, &R) -> T>>,
+}
+
+impl<K, L, R, Left, Right, T> Join<K, L, R, Left, Right, T>
+where
+    K: Tuple,
+    L: Tuple,
+    R: Tuple,
+    T: Tuple,
+    Left: Expression<(K, L)>,
+    Right: Expression<(K, R)>,
+{
+    pub fn new(left: &Left, right: &Right, project: impl FnMut(&K, &L, &R) -> T + 'static) -> Self {
+        Self {
+            left: left.clone(),
+            right: right.clone(),
+            mapper: Rc::new(RefCell::new(project)),
+        }
+    }
+
+    pub fn left(&self) -> &Left {
+        &self.left
+    }
+
+    pub fn right(&self) -> &Right {
+        &self.right
+    }
+
+    pub fn mapper(&self) -> &Rc<RefCell<dyn FnMut(&K, &L, &R) -> T>> {
+        &self.mapper
+    }
+}
+
+impl<K, L, R, Left, Right, T> Expression<T> for Join<K, L, R, Left, Right, T>
+where
+    K: Tuple,
+    L: Tuple,
+    R: Tuple,
+    T: Tuple,
+    Left: Expression<(K, L)>,
+    Right: Expression<(K, R)>,
+{
+    fn visit<V>(&self, visitor: &mut V)
+    where
+        V: Visitor,
+    {
+        visitor.visit_join(&self);
+    }
+
+    fn collect<C>(&self, collector: &C) -> Result<Tuples<T>>
+    where
+        C: super::Collector,
+    {
+        collector.collect_join(&self)
+    }
+
+    fn collect_list<C>(&self, collector: &C) -> Result<Vec<Tuples<T>>>
+    where
+        C: super::ListCollector,
+    {
+        collector.collect_join(&self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Database;
+
+    #[test]
+    fn test_clone_join() {
+        let mut database = Database::new();
+        let r = database.add_relation::<(i32, i32)>("r");
+        let s = database.add_relation::<(i32, i32)>("s");
+        r.insert(vec![(1, 10)].into(), &database).unwrap();
+        s.insert(vec![(1, 100)].into(), &database).unwrap();
+        let v = Join::new(&r, &s, |_, &l, &r| (l, r)).clone();
+        assert_eq!(
+            Tuples::<(i32, i32)>::from(vec![(10, 100)]),
+            database.evaluate(&v).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_evaluate_join() {
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<(i32, i32)>("r");
+            let s = database.add_relation::<(i32, i32)>("s");
+            let join = Join::new(&r, &s, |_, &l, &r| (l, r));
+
+            let result = database.evaluate(&join).unwrap();
+            assert_eq!(Tuples::<(i32, i32)>::from(vec![]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<(i32, i32)>("r");
+            let s = database.add_relation::<(i32, i32)>("s");
+            let join = Join::new(&r, &s, |_, &l, &r| (l, r));
+            r.insert(vec![(1, 4), (2, 2), (1, 3)].into(), &database)
+                .unwrap();
+            let result = database.evaluate(&join).unwrap();
+            assert_eq!(Tuples::<(i32, i32)>::from(vec![]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<(i32, i32)>("r");
+            let s = database.add_relation::<(i32, i32)>("s");
+            let join = Join::new(&r, &s, |_, &l, &r| (l, r));
+            s.insert(vec![(1, 5), (3, 2), (1, 6)].into(), &database)
+                .unwrap();
+
+            let result = database.evaluate(&join).unwrap();
+            assert_eq!(Tuples::<(i32, i32)>::from(vec![]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<(i32, i32)>("r");
+            let s = database.add_relation::<(i32, i32)>("s");
+            let join = Join::new(&r, &s, |_, &l, &r| (l, r));
+            r.insert(vec![(1, 4), (2, 2), (1, 3)].into(), &database)
+                .unwrap();
+            s.insert(vec![(1, 5), (3, 2), (1, 6)].into(), &database)
+                .unwrap();
+
+            let result = database.evaluate(&join).unwrap();
+            assert_eq!(
+                Tuples::<(i32, i32)>::from(vec![(3, 5), (3, 6), (4, 5), (4, 6)]),
+                result
+            );
+        }
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<(i32, i32)>("r");
+            let s = database.add_relation::<(i32, i32)>("s");
+            let t = database.add_relation::<(i32, i32)>("t");
+            let r_s = Join::new(&r, &s, |_, &l, &r| (l, r));
+            let r_s_t = Join::new(&r_s, &t, |_, _, &r| r);
+
+            r.insert(vec![(1, 4), (2, 2), (1, 3)].into(), &database)
+                .unwrap();
+            s.insert(vec![(1, 5), (3, 2), (1, 6)].into(), &database)
+                .unwrap();
+            t.insert(vec![(1, 40), (2, 41), (3, 42), (4, 43)].into(), &database)
+                .unwrap();
+
+            let result = database.evaluate(&r_s_t).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![42, 43]), result);
+        }
+        {
+            let mut database = Database::new();
+            let mut dummy = Database::new();
+            let r = database.add_relation::<(i32, i32)>("r");
+            let s = dummy.add_relation::<(i32, i32)>("s");
+            let join = Join::new(&r, &s, |_, &l, &r| (l, r));
+            assert!(database.evaluate(&join).is_err());
+        }
+    }
+}

--- a/core/src/expression/project.rs
+++ b/core/src/expression/project.rs
@@ -1,0 +1,122 @@
+use super::{Expression, Visitor};
+use crate::{database::Tuples, Tuple};
+use anyhow::Result;
+use std::{cell::RefCell, rc::Rc};
+
+#[derive(Clone)]
+pub struct Project<S, T, E>
+where
+    S: Tuple,
+    T: Tuple,
+    E: Expression<S>,
+{
+    expression: E,
+    mapper: Rc<RefCell<dyn FnMut(&S) -> T>>,
+}
+
+impl<S, T, E> Project<S, T, E>
+where
+    S: Tuple,
+    T: Tuple,
+    E: Expression<S>,
+{
+    pub fn new(expression: &E, project: impl FnMut(&S) -> T + 'static) -> Self {
+        Self {
+            expression: expression.clone(),
+            mapper: Rc::new(RefCell::new(project)),
+        }
+    }
+
+    pub fn expression(&self) -> &E {
+        &self.expression
+    }
+
+    pub(crate) fn mapper(&self) -> &Rc<RefCell<dyn FnMut(&S) -> T>> {
+        &self.mapper
+    }
+}
+
+impl<S, T, E> Expression<T> for Project<S, T, E>
+where
+    S: Tuple,
+    T: Tuple,
+    E: Expression<S>,
+{
+    fn visit<V>(&self, visitor: &mut V)
+    where
+        V: Visitor,
+    {
+        visitor.visit_project(&self);
+    }
+
+    fn collect<C>(&self, collector: &C) -> Result<Tuples<T>>
+    where
+        C: super::Collector,
+    {
+        collector.collect_project(&self)
+    }
+
+    fn collect_list<C>(&self, collector: &C) -> Result<Vec<Tuples<T>>>
+    where
+        C: super::ListCollector,
+    {
+        collector.collect_project(&self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Database;
+
+    #[test]
+    fn test_clone_project() {
+        let mut database = Database::new();
+        let r = database.add_relation::<i32>("r");
+        r.insert(vec![1, 2, 3].into(), &database).unwrap();
+        let p = Project::new(&r, |&t| t * 10).clone();
+        assert_eq!(
+            Tuples::<i32>::from(vec![10, 20, 30]),
+            database.evaluate(&p).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_evaluate_project() {
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<i32>("r");
+            let project = Project::new(&r, |t| t * 10);
+
+            let result = database.evaluate(&project).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<i32>("r");
+            let project = Project::new(&r, |t| t * 10);
+            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
+
+            let result = database.evaluate(&project).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![10, 20, 30, 40]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<i32>("r");
+            let p1 = Project::new(&r, |t| t * 10);
+            let p2 = Project::new(&p1, |t| t + 1);
+
+            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
+
+            let result = database.evaluate(&p2).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![11, 21, 31, 41]), result);
+        }
+        {
+            let database = Database::new();
+            let mut dummy = Database::new();
+            let r = dummy.add_relation::<i32>("r");
+            let project = Project::new(&r, |t| t + 1);
+            assert!(database.evaluate(&project).is_err());
+        }
+    }
+}

--- a/core/src/expression/relation.rs
+++ b/core/src/expression/relation.rs
@@ -1,0 +1,131 @@
+use super::{Expression, Visitor};
+use crate::{
+    database::{Database, Tuples},
+    Tuple,
+};
+use anyhow::Result;
+use std::marker::PhantomData;
+
+#[derive(Clone)]
+pub struct Relation<T>
+where
+    T: Tuple,
+{
+    pub(crate) name: String,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> Relation<T>
+where
+    T: Tuple,
+{
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn insert(&self, tuples: Tuples<T>, db: &Database) -> Result<()> {
+        let relation = db.relation_instance(&self)?;
+        relation.insert(tuples);
+        Ok(())
+    }
+}
+
+impl<T> Expression<T> for Relation<T>
+where
+    T: Tuple,
+{
+    fn visit<V>(&self, visitor: &mut V)
+    where
+        V: Visitor,
+    {
+        visitor.visit_relation(&self);
+    }
+
+    fn collect<C>(&self, collector: &C) -> Result<Tuples<T>>
+    where
+        C: super::Collector,
+    {
+        collector.collect_relation(&self)
+    }
+
+    fn collect_list<C>(&self, collector: &C) -> Result<Vec<Tuples<T>>>
+    where
+        C: super::ListCollector,
+    {
+        collector.collect_relation(&self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_relation() {
+        assert_eq!("a".to_string(), Relation::<i32>::new("a").name);
+    }
+
+    #[test]
+    fn test_insert_relation() {
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<i32>("r");
+            assert!(r.insert(vec![1, 2, 3].into(), &database).is_ok());
+            assert_eq!(
+                Tuples::<i32>::from(vec![1, 2, 3]),
+                database.relation_instance(&r).unwrap().to_add.borrow()[0]
+            );
+        }
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<i32>("r");
+            assert!(r.insert(vec![1, 2, 3].into(), &database).is_ok());
+            assert!(r.insert(vec![1, 4].into(), &database).is_ok());
+            assert_eq!(
+                Tuples::<i32>::from(vec![1, 2, 3]),
+                database.relation_instance(&r).unwrap().to_add.borrow()[0]
+            );
+            assert_eq!(
+                Tuples::<i32>::from(vec![1, 4]),
+                database.relation_instance(&r).unwrap().to_add.borrow()[1]
+            );
+        }
+        {
+            let database = Database::new();
+            let r = Database::new().add_relation("r"); // dummy database
+            assert!(r.insert(vec![1, 2, 3].into(), &database).is_err());
+        }
+    }
+
+    #[test]
+    fn test_clone_relation() {
+        let mut database = Database::new();
+        let r = database.add_relation::<i32>("r");
+        r.insert(vec![1, 2, 3].into(), &database).unwrap();
+        assert_eq!(
+            Tuples::<i32>::from(vec![1, 2, 3]),
+            database.evaluate(&r.clone()).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_evaluate_relation() {
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<i32>("r");
+            r.insert(vec![1, 2, 3].into(), &database).unwrap();
+            let result = database.evaluate(&r).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![1, 2, 3]), result);
+        }
+        {
+            let database = Database::new();
+            let mut dummy = Database::new();
+            let r = dummy.add_relation::<i32>("r");
+
+            assert!(database.evaluate(&r).is_err());
+        }
+    }
+}

--- a/core/src/expression/select.rs
+++ b/core/src/expression/select.rs
@@ -1,0 +1,122 @@
+use super::{Expression, Visitor};
+use crate::{database::Tuples, Tuple};
+use anyhow::Result;
+use std::{cell::RefCell, rc::Rc};
+
+#[derive(Clone)]
+pub struct Select<T, E>
+where
+    T: Tuple,
+    E: Expression<T>,
+{
+    expression: E,
+    predicate: Rc<RefCell<dyn FnMut(&T) -> bool>>,
+}
+
+impl<T, E> Select<T, E>
+where
+    T: Tuple,
+    E: Expression<T>,
+{
+    pub fn new<P>(expression: &E, predicate: P) -> Self
+    where
+        P: FnMut(&T) -> bool + 'static,
+    {
+        Self {
+            expression: expression.clone(),
+            predicate: Rc::new(RefCell::new(predicate)),
+        }
+    }
+
+    pub fn expression(&self) -> &E {
+        &self.expression
+    }
+
+    pub(crate) fn predicate(&self) -> &Rc<RefCell<dyn FnMut(&T) -> bool>> {
+        &self.predicate
+    }
+}
+
+impl<T, E> Expression<T> for Select<T, E>
+where
+    T: Tuple,
+    E: Expression<T>,
+{
+    fn visit<V>(&self, visitor: &mut V)
+    where
+        V: Visitor,
+    {
+        visitor.visit_select(&self);
+    }
+
+    fn collect<C>(&self, collector: &C) -> Result<Tuples<T>>
+    where
+        C: super::Collector,
+    {
+        collector.collect_select(&self)
+    }
+
+    fn collect_list<C>(&self, collector: &C) -> Result<Vec<Tuples<T>>>
+    where
+        C: super::ListCollector,
+    {
+        collector.collect_select(&self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Database;
+
+    #[test]
+    fn test_clone_select() {
+        let mut database = Database::new();
+        let r = database.add_relation::<i32>("r");
+        r.insert(vec![1, 2, 3].into(), &database).unwrap();
+        let p = Select::new(&r, |&t| t % 2 == 1).clone();
+        assert_eq!(
+            Tuples::<i32>::from(vec![1, 3]),
+            database.evaluate(&p).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_evaluate_select() {
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<i32>("r");
+            let project = Select::new(&r, |t| t % 2 == 1);
+
+            let result = database.evaluate(&project).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<i32>("r");
+            let select = Select::new(&r, |t| t % 2 == 0);
+            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
+
+            let result = database.evaluate(&select).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![2, 4]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<i32>("r");
+            let p1 = Select::new(&r, |t| t % 2 == 0);
+            let p2 = Select::new(&p1, |&t| t > 3);
+
+            r.insert(vec![1, 2, 3, 4].into(), &database).unwrap();
+
+            let result = database.evaluate(&p2).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![4]), result);
+        }
+        {
+            let database = Database::new();
+            let mut dummy = Database::new();
+            let r = dummy.add_relation::<i32>("r");
+            let select = Select::new(&r, |&t| t > 1);
+            assert!(database.evaluate(&select).is_err());
+        }
+    }
+}

--- a/core/src/expression/view.rs
+++ b/core/src/expression/view.rs
@@ -1,0 +1,155 @@
+use super::{Expression, Visitor};
+use crate::{
+    database::{Tuples, ViewRef},
+    Tuple,
+};
+use anyhow::Result;
+use std::marker::PhantomData;
+
+#[derive(Clone)]
+pub struct View<T, E>
+where
+    T: Tuple,
+    E: Expression<T>,
+{
+    pub(crate) reference: ViewRef,
+    _phantom: PhantomData<(T, E)>,
+}
+
+impl<T, E> View<T, E>
+where
+    T: Tuple,
+    E: Expression<T>,
+{
+    pub(crate) fn new(reference: ViewRef) -> Self {
+        Self {
+            reference,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, E> Expression<T> for View<T, E>
+where
+    T: Tuple + 'static,
+    E: Expression<T> + 'static,
+{
+    fn visit<V>(&self, visitor: &mut V)
+    where
+        V: Visitor,
+    {
+        visitor.visit_view(&self);
+    }
+
+    fn collect<C>(&self, collector: &C) -> Result<Tuples<T>>
+    where
+        C: super::Collector,
+    {
+        collector.collect_view(&self)
+    }
+
+    fn collect_list<C>(&self, collector: &C) -> Result<Vec<Tuples<T>>>
+    where
+        C: super::ListCollector,
+    {
+        collector.collect_view(&self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::Join;
+    use super::*;
+    use crate::Database;
+
+    #[test]
+    fn test_clone_view() {
+        let mut database = Database::new();
+        let r = database.add_relation::<i32>("r");
+        let v = database.store_view(&r).clone();
+        r.insert(vec![1, 2, 3].into(), &database).unwrap();
+        assert_eq!(
+            Tuples::<i32>::from(vec![1, 2, 3]),
+            database.evaluate(&v).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_evaluate_view() {
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<i32>("r");
+            let v = database.store_view(&r);
+            r.insert(vec![1, 2, 3].into(), &database).unwrap();
+            let result = database.evaluate(&v).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![1, 2, 3]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<i32>("r");
+            let v_1 = database.store_view(&r);
+            let v_2 = database.store_view(&v_1);
+            let v_3 = database.store_view(&v_2);
+            r.insert(vec![1, 2, 3].into(), &database).unwrap();
+            let result = database.evaluate(&v_3).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![1, 2, 3]), result);
+        }
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<(i32, i32)>("r");
+            let s = database.add_relation::<(i32, i32)>("s");
+            let r_s = Join::new(&r, &s, |_, &l, &r| (l, r));
+            let view = database.store_view(&r_s);
+
+            r.insert(vec![(1, 4), (2, 2), (1, 3)].into(), &database)
+                .unwrap();
+            s.insert(vec![(1, 5), (3, 2), (1, 6)].into(), &database)
+                .unwrap();
+
+            let result = database.evaluate(&view).unwrap();
+            assert_eq!(
+                Tuples::<(i32, i32)>::from(vec![(3, 5), (3, 6), (4, 5), (4, 6)]),
+                result
+            );
+        }
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<(i32, i32)>("r");
+            let s = database.add_relation::<(i32, i32)>("s");
+            let r_s = Join::new(&r, &s, |_, &l, &r| (l, r));
+            let view = database.store_view(&r_s);
+
+            r.insert(vec![(1, 4), (2, 2), (1, 3)].into(), &database)
+                .unwrap();
+            s.insert(vec![(1, 5), (3, 2), (1, 6)].into(), &database)
+                .unwrap();
+
+            database.evaluate(&view).unwrap();
+            s.insert(vec![(1, 7)].into(), &database).unwrap();
+            let result = database.evaluate(&view).unwrap();
+            assert_eq!(
+                Tuples::<(i32, i32)>::from(vec![(3, 5), (3, 6), (3, 7), (4, 5), (4, 6), (4, 7)]),
+                result
+            );
+        }
+        {
+            let mut database = Database::new();
+            let r = database.add_relation::<(i32, i32)>("r");
+            let s = database.add_relation::<(i32, i32)>("s");
+            let t = database.add_relation::<(i32, i32)>("t");
+            let r_s = Join::new(&r, &s, |_, &l, &r| (l, r));
+            let r_s_t = Join::new(&r_s, &t, |_, _, &r| r);
+            let view = database.store_view(&r_s_t);
+
+            r.insert(vec![(1, 4), (2, 2), (1, 3)].into(), &database)
+                .unwrap();
+            s.insert(vec![(1, 5), (3, 2), (1, 6)].into(), &database)
+                .unwrap();
+            t.insert(vec![(1, 40), (2, 41), (3, 42), (4, 43)].into(), &database)
+                .unwrap();
+
+            let result = database.evaluate(&view).unwrap();
+            assert_eq!(Tuples::<i32>::from(vec![42, 43]), result);
+        }
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,5 +6,5 @@ mod tools;
 pub use database::{Database, Tuples};
 pub use expression::{Expression, Join, Project, Relation, Select, View};
 
-pub trait Tuple: Ord + Clone {}
-impl<T: Ord + Clone> Tuple for T {}
+pub trait Tuple: Ord + Clone + 'static {}
+impl<T: Ord + Clone + 'static> Tuple for T {}

--- a/core/src/tools.rs
+++ b/core/src/tools.rs
@@ -1,5 +1,26 @@
 use crate::{database::Tuples, Tuple};
 
+pub(crate) fn gallop<T>(mut slice: &[T], mut cmp: impl FnMut(&T) -> bool) -> &[T] {
+    if slice.len() > 0 && cmp(&slice[0]) {
+        let mut step = 1;
+        while step < slice.len() && cmp(&slice[step]) {
+            slice = &slice[step..];
+            step = step << 1;
+        }
+
+        step = step >> 1;
+        while step > 0 {
+            if step < slice.len() && cmp(&slice[step]) {
+                slice = &slice[step..];
+            }
+            step = step >> 1;
+        }
+
+        slice = &slice[1..];
+    }
+    slice
+}
+
 pub(crate) fn project_helper<T: Tuple>(input: &Tuples<T>, mut result: impl FnMut(&T)) {
     let slice = &input[..];
     for tuple in slice {
@@ -36,25 +57,4 @@ pub(crate) fn join_helper<Key: Tuple, Val1: Tuple, Val2: Tuple>(
             Ordering::Greater => slice2 = gallop(slice2, |x| x.0 < slice1[0].0),
         }
     }
-}
-
-pub(crate) fn gallop<T>(mut slice: &[T], mut cmp: impl FnMut(&T) -> bool) -> &[T] {
-    if slice.len() > 0 && cmp(&slice[0]) {
-        let mut step = 1;
-        while step < slice.len() && cmp(&slice[step]) {
-            slice = &slice[step..];
-            step = step << 1;
-        }
-
-        step = step >> 1;
-        while step > 0 {
-            if step < slice.len() && cmp(&slice[step]) {
-                slice = &slice[step..];
-            }
-            step = step >> 1;
-        }
-
-        slice = &slice[1..];
-    }
-    slice
 }


### PR DESCRIPTION
Database is responsible for evaluating expressions: Expressions implement visit, collect and collect_list to accent a Visitor, Collector and ListCollector respectively. Evaluator implements Collector.
Non-recursive query evaluation: views are assumed to be non-recursive. When evaluating an expression, all underlying subexpressions are evaluated before the expression itself is evaluated. Other unrelated relations and views remain unchained.
Expressions are broken down in their own modules.
Expressions do not use object traits to store subexpressions.